### PR TITLE
refactor(layout): unify section spacing and remove absolute positioning from Contact

### DIFF
--- a/app/assets/css/styles.css
+++ b/app/assets/css/styles.css
@@ -64,8 +64,11 @@ img {
 }
 
 body {
-  padding: 0 280px;
   background-color: var(--color-layer0);
+}
+
+.block-section {
+  margin: 0 280px;
 }
 
 .block-layer1 {

--- a/app/components/About.vue
+++ b/app/components/About.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-row justify-center items-center min-h-screen gap-8">
+  <div class="block-section flex flex-row justify-center items-center min-h-screen gap-8">
     <div class="about relative flex flex-col h-fit gap-8 w-1/2">
       <div class="flex flex-col block-layer1 bg-neutral-900 gap-4" style="padding: 2rem">
         <p class="deep relative explain text-neutral-400 text-sm">

--- a/app/components/Contact.vue
+++ b/app/components/Contact.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="grid grid-cols-[1fr_minmax(0,28rem)_1fr] absolute left-0 w-[99vw] min-h-screen items-center justify-center"
-  >
+  <div class="grid grid-cols-[1fr_minmax(0,28rem)_1fr] min-h-screen items-center justify-center">
     <div class="bg-[url(/l-hand.png)] hands h-screen"></div>
 
     <form

--- a/app/components/Hero.vue
+++ b/app/components/Hero.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex gap-10 overflow-x-hidden min-h-screen items-center justify-center">
+  <div class="block-section flex gap-10 overflow-x-hidden min-h-screen items-center justify-center">
     <div class="block-layer1 bg-neutral-900 flex flex-col gap-5">
       <div class="block-layer2 bg-neutral-800 inline-flex gap-5">
         <div class="inline-table">

--- a/app/components/Work.vue
+++ b/app/components/Work.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col w-full min-h-screen gap-52 py-32">
+  <div class="block-section flex flex-col min-h-screen gap-52 py-32">
     <!-- CODE SECTION -->
     <div
       class="relative grid grid-cols-[repeat(auto-fit,minmax(350px,1fr))] gap-8 overlay-label"


### PR DESCRIPTION
# 🧩 Pull Request

## ✨ Тип изменений

> Выбери одно или несколько, лишние удалить

- `fix` — исправление ошибок
- `refactor` — улучшение структуры кода

---

## 📋 Описание

> Кратко опиши, что сделано и зачем. Укажи, если были визуальные изменения (можно добавить скриншот или ссылку на Figma).

Заменил padding в body на переиспользуемый класс .block-section с margin: 0 280px, чтобы все основные секции (Hero, About, Work) имели единый отступ от краёв экрана и оставались в нормальном потоке документа.
Убрал absolute позиционирование из компонента Contact, так как оно вызывало наложение на другие элементы (например, футер) и нарушало layout flow.
В Contact сознательно не используется .block-section, потому что боковые декоративные "руки" (l-hand.png, r-hand.png) должны тянуться от края экрана - это требует полной ширины контейнера.

---

## 🧠 Причина изменений

> Почему эти изменения важны?

Абсолютное позиционирование в Contact ломало поток документа - при добавлении новых секций (например, футера) они наезжали друг на друга.
Переход на margin-базированный подход с классом .block-section делает layout более предсказуемым, совместимым с адаптивом и проще в поддержке, при этом сохраняя гибкость для специфичных компонентов вроде Contact.

---

## 🧪 Проверено
> Использовать символы ❌, ✅ не использовать **checkbox list!**
- ✅ Локально запущено и проверено
- ❌ Проверен адаптив
- ✅ Нет ошибок в консоли
- ✅ Проверен деплой / билд
- ✅ Код соответствует ESLint / Prettier

---

## 🧷 Дополнительно

> Любые дополнительные комментарии, TODO или планы на будущее, **обязательно** использовать **checkbox list!**

- [ ] В будущем вынести 280px в CSS-переменную для централизованного управления.