### PR TITLE
fix(header): center the header in a firefox-based browser

### DIFF
--- a/app/components/Header.vue
+++ b/app/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="flex justify-center items-center gap-8 fixed top-4 w-fit place-self-center z-50">
+  <header class="flex justify-center items-center gap-8 fixed top-4 w-full mx-auto z-50">
     <a class="btn px-6 py-3 rounded-xl header__link" href="/blog">Blog</a>
     <a class="btn px-6 py-3 rounded-xl header__link" href="#projects">Projects</a>
     <a class="btn px-6 py-2 rounded-xl header__link" href="/">


### PR DESCRIPTION
# 🧩 Pull Request

## ✨ Тип изменений

- `fix` — исправление ошибок

---

## 📋 Описание

Центрировал Header для браузера на базе Firefox

---

## 🧠 Причина изменений

В браузере на базе Chromium header отображался корректно по центру, а в Firefox он уехал к левому краю экрана